### PR TITLE
Swap dfu-util git url

### DIFF
--- a/src/update_dfu-util.sh
+++ b/src/update_dfu-util.sh
@@ -13,7 +13,7 @@ if [ -d dfu-util ]; then
 	
 else
 	echo "First time git clone: installing"
-	git clone git://gitorious.org/dfu-util/dfu-util.git
+	git clone git://git.code.sf.net/p/dfu-util/dfu-util
 	cd dfu-util
 	./autogen.sh
 	./configure


### PR DESCRIPTION
I got an error when trying to install dfu-util. It said gitorious
wasn't up.

I went there in a browser, and it looks like they're pushing their
repositories to the Internet Archive project to be in read-only
mode. I swapped out the git url from gitorious.org to the one
listed on the dfu-util page.

Afterward, everything built fine.
